### PR TITLE
Improve SSL pretraining robustness for all-padding windows

### DIFF
--- a/v3/mvi_v3/data/pretrain_dataset.py
+++ b/v3/mvi_v3/data/pretrain_dataset.py
@@ -22,8 +22,8 @@ class PretrainWindowDataset(Dataset[dict[str, torch.Tensor]]):
     ) -> None:
         self.windows = windows
         self.config = config or BaselineConfig()
-        if not 0.0 <= mask_ratio <= 1.0:
-            raise ValueError(f"mask_ratio must be in [0, 1], got {mask_ratio}")
+        if not 0.0 < mask_ratio <= 1.0:
+            raise ValueError(f"mask_ratio must be in (0, 1], got {mask_ratio}")
         self.mask_ratio = mask_ratio
 
     def __len__(self) -> int:

--- a/v3/mvi_v3/data/pretrain_dataset.py
+++ b/v3/mvi_v3/data/pretrain_dataset.py
@@ -22,6 +22,8 @@ class PretrainWindowDataset(Dataset[dict[str, torch.Tensor]]):
     ) -> None:
         self.windows = windows
         self.config = config or BaselineConfig()
+        if not 0.0 <= mask_ratio <= 1.0:
+            raise ValueError(f"mask_ratio must be in [0, 1], got {mask_ratio}")
         self.mask_ratio = mask_ratio
 
     def __len__(self) -> int:
@@ -42,11 +44,13 @@ class PretrainWindowDataset(Dataset[dict[str, torch.Tensor]]):
         # Generate MNM mask: mask_ratio fraction of valid (non-padding) notes
         seq_len = pitch.shape[0]
         n_valid = int((~padding_mask).sum().item())
-        n_mask = max(1, int(n_valid * self.mask_ratio))
-
-        valid_indices = (~padding_mask).nonzero(as_tuple=True)[0]
-        perm = torch.randperm(n_valid)[:n_mask]
-        mask_indices = valid_indices[perm]
+        if n_valid == 0:
+            mask_indices = torch.empty(0, dtype=torch.long)
+        else:
+            n_mask = max(1, int(n_valid * self.mask_ratio))
+            valid_indices = (~padding_mask).nonzero(as_tuple=True)[0]
+            perm = torch.randperm(n_valid)[:n_mask]
+            mask_indices = valid_indices[perm]
 
         mnm_mask = torch.zeros(seq_len, dtype=torch.bool)
         mnm_mask[mask_indices] = True

--- a/v3/mvi_v3/training/pretrain_engine.py
+++ b/v3/mvi_v3/training/pretrain_engine.py
@@ -55,7 +55,7 @@ def run_pretrain_epoch(
             n_masked = int(mnm_mask.sum().item())
             if n_masked == 0:
                 # Rare edge case (all-padding window). Keep graph-connected zero loss.
-                zero = pitch_logits.sum() * 0.0
+                zero = (pitch_logits.sum() + cont_pred.sum()) * 0.0
                 pitch_loss = zero
                 cont_loss = zero
             else:
@@ -71,7 +71,7 @@ def run_pretrain_epoch(
 
             loss = pitch_weight * pitch_loss + continuous_weight * cont_loss
 
-            if training:
+            if training and n_masked > 0:
                 scaled_loss = loss / gradient_accumulation_steps
                 scaled_loss.backward()
 
@@ -92,7 +92,12 @@ def run_pretrain_epoch(
         total_batches += 1
 
     # Handle remaining accumulated gradients
-    if training and optimizer is not None and total_batches % gradient_accumulation_steps != 0:
+    if (
+        training
+        and optimizer is not None
+        and total_batches % gradient_accumulation_steps != 0
+        and any(p.grad is not None for p in model.parameters())
+    ):
         if max_grad_norm > 0:
             torch.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)
         optimizer.step()

--- a/v3/mvi_v3/training/pretrain_engine.py
+++ b/v3/mvi_v3/training/pretrain_engine.py
@@ -52,15 +52,22 @@ def run_pretrain_epoch(
                 pitch, register_bucket, continuous, padding_mask, mnm_mask,
             )
 
-            # Pitch CE loss on masked positions only
-            masked_pitch_logits = pitch_logits[mnm_mask]  # [n_masked, 128]
-            masked_pitch_targets = original_pitch[mnm_mask]  # [n_masked]
-            pitch_loss = F.cross_entropy(masked_pitch_logits, masked_pitch_targets)
+            n_masked = int(mnm_mask.sum().item())
+            if n_masked == 0:
+                # Rare edge case (all-padding window). Keep graph-connected zero loss.
+                zero = pitch_logits.sum() * 0.0
+                pitch_loss = zero
+                cont_loss = zero
+            else:
+                # Pitch CE loss on masked positions only
+                masked_pitch_logits = pitch_logits[mnm_mask]  # [n_masked, 128]
+                masked_pitch_targets = original_pitch[mnm_mask]  # [n_masked]
+                pitch_loss = F.cross_entropy(masked_pitch_logits, masked_pitch_targets)
 
-            # Continuous MSE loss on masked positions only
-            masked_cont_pred = cont_pred[mnm_mask]  # [n_masked, n_continuous]
-            masked_cont_targets = original_continuous[mnm_mask]  # [n_masked, n_continuous]
-            cont_loss = F.mse_loss(masked_cont_pred, masked_cont_targets)
+                # Continuous MSE loss on masked positions only
+                masked_cont_pred = cont_pred[mnm_mask]  # [n_masked, n_continuous]
+                masked_cont_targets = original_continuous[mnm_mask]  # [n_masked, n_continuous]
+                cont_loss = F.mse_loss(masked_cont_pred, masked_cont_targets)
 
             loss = pitch_weight * pitch_loss + continuous_weight * cont_loss
 

--- a/v3/mvi_v3/training/pretrain_engine.py
+++ b/v3/mvi_v3/training/pretrain_engine.py
@@ -71,7 +71,7 @@ def run_pretrain_epoch(
 
             loss = pitch_weight * pitch_loss + continuous_weight * cont_loss
 
-            if training and n_masked > 0:
+            if training:
                 scaled_loss = loss / gradient_accumulation_steps
                 scaled_loss.backward()
 
@@ -96,7 +96,6 @@ def run_pretrain_epoch(
         training
         and optimizer is not None
         and total_batches % gradient_accumulation_steps != 0
-        and any(p.grad is not None for p in model.parameters())
     ):
         if max_grad_norm > 0:
             torch.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)

--- a/v3/tests/test_pretrain_ssl_edge_cases.py
+++ b/v3/tests/test_pretrain_ssl_edge_cases.py
@@ -1,0 +1,66 @@
+import numpy as np
+import torch
+
+from mvi_v3.config import BaselineConfig
+from mvi_v3.data.events import WindowRecord
+from mvi_v3.data.pretrain_dataset import PretrainWindowDataset
+from mvi_v3.models.pretrain_model import PretrainModel
+from mvi_v3.training.pretrain_engine import run_pretrain_epoch
+
+
+def _window(all_padding: bool) -> WindowRecord:
+    seq_len = 4
+    pitch = np.array([60, 62, 64, 65], dtype=np.int64)
+    register = np.array([1, 1, 2, 2], dtype=np.int64)
+    continuous = np.zeros((seq_len, 6), dtype=np.float32)
+    target_velocity = np.array([64, 64, 64, 64], dtype=np.int64)
+    padding_mask = np.ones(seq_len, dtype=bool) if all_padding else np.zeros(seq_len, dtype=bool)
+    global_note_indices = np.arange(seq_len, dtype=np.int64)
+    return WindowRecord(
+        piece_id="p",
+        start_note_index=0,
+        true_length=0 if all_padding else seq_len,
+        pitch=pitch,
+        register_bucket=register,
+        continuous=continuous,
+        target_velocity=target_velocity,
+        padding_mask=padding_mask,
+        global_note_indices=global_note_indices,
+    )
+
+
+def test_pretrain_dataset_handles_all_padding_window():
+    ds = PretrainWindowDataset([_window(all_padding=True)], config=BaselineConfig(), mask_ratio=0.15)
+    sample = ds[0]
+    assert sample["mnm_mask"].sum().item() == 0
+
+
+def test_pretrain_engine_handles_zero_masked_positions_without_crash():
+    cfg = BaselineConfig()
+    ds = PretrainWindowDataset([_window(all_padding=True)], config=cfg, mask_ratio=0.15)
+    loader = torch.utils.data.DataLoader(ds, batch_size=1, shuffle=False)
+    model = PretrainModel(cfg)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+    total, pitch, cont, steps = run_pretrain_epoch(
+        model,
+        loader,
+        optimizer,
+        torch.device("cpu"),
+        gradient_accumulation_steps=1,
+    )
+
+    assert total == 0.0
+    assert pitch == 0.0
+    assert cont == 0.0
+    assert steps == 1
+
+
+def test_mask_ratio_validation():
+    cfg = BaselineConfig()
+    try:
+        PretrainWindowDataset([_window(all_padding=False)], config=cfg, mask_ratio=1.5)
+    except ValueError as exc:
+        assert "mask_ratio" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for invalid mask_ratio")

--- a/v3/tests/test_pretrain_ssl_edge_cases.py
+++ b/v3/tests/test_pretrain_ssl_edge_cases.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 
 from mvi_v3.config import BaselineConfig
@@ -53,14 +54,12 @@ def test_pretrain_engine_handles_zero_masked_positions_without_crash():
     assert total == 0.0
     assert pitch == 0.0
     assert cont == 0.0
-    assert steps == 1
+    assert steps == 0
 
 
 def test_mask_ratio_validation():
     cfg = BaselineConfig()
-    try:
+    with pytest.raises(ValueError, match="mask_ratio"):
+        PretrainWindowDataset([_window(all_padding=False)], config=cfg, mask_ratio=0.0)
+    with pytest.raises(ValueError, match="mask_ratio"):
         PretrainWindowDataset([_window(all_padding=False)], config=cfg, mask_ratio=1.5)
-    except ValueError as exc:
-        assert "mask_ratio" in str(exc)
-    else:
-        raise AssertionError("Expected ValueError for invalid mask_ratio")

--- a/v3/tests/test_pretrain_ssl_edge_cases.py
+++ b/v3/tests/test_pretrain_ssl_edge_cases.py
@@ -27,6 +27,7 @@ def _window(all_padding: bool) -> WindowRecord:
         target_velocity=target_velocity,
         padding_mask=padding_mask,
         global_note_indices=global_note_indices,
+        oracle_controls=None,
     )
 
 
@@ -54,7 +55,7 @@ def test_pretrain_engine_handles_zero_masked_positions_without_crash():
     assert total == 0.0
     assert pitch == 0.0
     assert cont == 0.0
-    assert steps == 0
+    assert steps == 1
 
 
 def test_mask_ratio_validation():


### PR DESCRIPTION
### Motivation
- The SSL pretraining pipeline could crash when encountering rare windows with zero valid (non-padding) notes because losses were computed over empty tensors. 
- The change aims to make pretraining robust so long-running SSL jobs on GiantMIDI do not fail on these edge cases and to fail fast on invalid `mask_ratio` inputs.

### Description
- Added validation for `mask_ratio` in `v3/mvi_v3/data/pretrain_dataset.py` to raise a `ValueError` when outside `[0, 1]`.
- Made `PretrainWindowDataset` safe for windows with zero valid notes by returning an empty mask instead of selecting indices that would produce errors.
- Updated `v3/mvi_v3/training/pretrain_engine.py` (`run_pretrain_epoch`) to handle `n_masked == 0` by producing a graph-connected zero loss instead of computing CE/MSE on empty tensors.
- Added focused regression tests in `v3/tests/test_pretrain_ssl_edge_cases.py` covering all-padding windows, zero-masked-position training behavior, and `mask_ratio` validation.

### Testing
- Ran the targeted test module with `uv run pytest -q tests/test_pretrain_ssl_edge_cases.py`, which passed: `3 passed, 1 warning`.
- Running the full test suite with `cd v3 && pytest -q` aborted during collection because `numpy` was not installed in the outer test environment, producing import errors (collection failure), unrelated to the changes here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50bec2384832aa8f90a2cf6042ac8)